### PR TITLE
chore: use shared dependency update action

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -9,8 +9,8 @@ jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Push branches
-      pull-requests: write # Create PRs
+      contents: write # Push branches, merge PRs, delete branches
+      pull-requests: write # Create and merge PRs
     steps:
       - name: Run dependency update
-        uses: cloud-copilot/update-dependencies@main
+        uses: cloud-copilot/action-update-dependencies@fe48d42724df9c4ed34abf9c0cc97a8da42917f4


### PR DESCRIPTION
## Summary
- switch the dependency update workflow to `cloud-copilot/action-update-dependencies` pinned at `fe48d42724df9c4ed34abf9c0cc97a8da42917f4`
- keep the workflow limited to dependency update, PR creation, merge, and branch deletion

## Testing
- Parsed updated workflow YAML locally with Ruby YAML loader